### PR TITLE
Add pointer masking terms and acronyms

### DIFF
--- a/src/acronyms.adoc
+++ b/src/acronyms.adoc
@@ -313,6 +313,8 @@
 
 [[NUMA]]NUMA:: Non-uniform Memory Access.
 
+[[NVBITS]]NVBITS:: Non-effective Virtual Address Bits. Upper bits of a virtual address that have no effect on memory addressing and are used only for address-validity checks. Used by pointer masking.
+
 [[OBJ]]OBJ:: Object.
 
 [[OCF]]OCF:: Operation Code Field.
@@ -349,7 +351,13 @@
 
 [[PLL]]PLL:: Phase-Locked Loop.
 
+[[PM]]PM:: Pointer Masking. An operation that transforms an address by masking a number of its upper bits before the address is used to access memory.
+
 [[PMA]]PMA:: Physical Memory Attributes.
+
+[[PMLEN]]PMLEN:: Pointer Masking Length. The number of upper address bits that are masked by pointer masking.
+
+[[PMM]]PMM:: Pointer Masking Mode. The CSR field that configures pointer-masking behavior.
 
 [[PMP]]PMP:: Physical Memory Protection.
 
@@ -534,6 +542,8 @@
 [[URET]]URET:: User Return from Trap.
 
 [[VA]]VA:: Virtual Address.
+
+[[VBITS]]VBITS:: Virtual Address Bits. The bits within a virtual address that determine which memory is addressed. See <<NVBITS>>.
 
 [[vcsr]]vcsr:: Vector Control and Status register.
 

--- a/src/acronyms.adoc
+++ b/src/acronyms.adoc
@@ -313,7 +313,7 @@
 
 [[NUMA]]NUMA:: Non-uniform Memory Access.
 
-[[NVBITS]]NVBITS:: Non-effective Virtual Address Bits. Upper bits of a virtual address that have no effect on memory addressing and are used only for address-validity checks. Used by pointer masking.
+[[NVBITS]]NVBITS:: Non-effective Virtual Address Bits.
 
 [[OBJ]]OBJ:: Object.
 
@@ -351,13 +351,13 @@
 
 [[PLL]]PLL:: Phase-Locked Loop.
 
-[[PM]]PM:: Pointer Masking. An operation that transforms an address by masking a number of its upper bits before the address is used to access memory.
+[[PM]]PM:: Pointer Masking.
 
 [[PMA]]PMA:: Physical Memory Attributes.
 
-[[PMLEN]]PMLEN:: Pointer Masking Length. The number of upper address bits that are masked by pointer masking.
+[[PMLEN]]PMLEN:: Pointer Masking Length.
 
-[[PMM]]PMM:: Pointer Masking Mode. The CSR field that configures pointer-masking behavior.
+[[PMM]]PMM:: Pointer Masking Mode.
 
 [[PMP]]PMP:: Physical Memory Protection.
 
@@ -543,7 +543,7 @@
 
 [[VA]]VA:: Virtual Address.
 
-[[VBITS]]VBITS:: Virtual Address Bits. The bits within a virtual address that determine which memory is addressed. See <<NVBITS>>.
+[[VBITS]]VBITS:: Virtual Address Bits.
 
 [[vcsr]]vcsr:: Vector Control and Status register.
 

--- a/src/glossary.adoc
+++ b/src/glossary.adoc
@@ -83,6 +83,8 @@ unique device identifier to locate the Device Context structure.
 
 [[ECOFF]]ECOFF:: Extended Common Object File Format. Used on Alpha Digital Unix (formerly OSF/1), as well as Ultrix and Irix 4. A variant of COFF.
 
+[[effectiveaddress]]Effective address:: A load or store address sent to the memory subsystem, excluding implicit accesses such as page-table walks.
+
 [[EP]]EP:: Error/poisoned. Follows PCI Express. Also called Data Poisoning. EP is an error flag that accompanies data in some PCIe transactions to indicate the data is known to contain an error. Defined in PCI Express Base Specification 6.0 section 2.7.2. Unless otherwise blocked, the poison associated with the data must continue to propagate in the SoC internal interconnect.
 
 [[ES]]ES:: Entropy Source. An input or a measured characteristic that supplies random bits for an I/O device on a computer, usually used to supply bits that an attacker cannot know, as part of security.
@@ -140,6 +142,8 @@ that the implementation enforces. Measured in bits.
 
 [[IIRC]]IIRC:: The International Integrated Reporting Council, previously the International Integrated Reporting Committee), was formed in August 2010 and aims to create a globally accepted framework for a process that results in communications by an organization about value creation over time.
 
+[[ignoretransformation]]Ignore transformation:: A pointer-masking operation that replaces the upper PMLEN bits of an address with the sign-extended value of the most significant retained bit for virtual addresses, or with zeros for physical addresses.
+
 [[ILEN]]ILEN:: Refers to the maximum instruction length supported by an
 implementation. ILEN is a multiple of IALIGN and measured in bits.
 
@@ -172,6 +176,8 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 [[M]]M:: Machine Mode. A boot mode that allows access to the most trusted code. This mode is required in all RISC-V implementations. Also called M-mode. See 1.2. Privilege Levels.
 
 [[MCTP]]MCTP:: Management Component Transport Protocol used for communication between components of a platform management system. Follows DMTF Standard. 
+
+[[maskedbits]]Masked bits:: The upper PMLEN bits of an address that are subject to pointer masking.
 
 [[MIPS]]MIPS:: Microprocessor without Interlocked Pipelined Stages. A reduced instruction set computer (RISC) instruction set architecture developed by MIPS Computer Systems, now MIPS Technologies, based in the United States, that influenced later RISC architectures.
 
@@ -224,6 +230,8 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 [[POSIX]]POSIX:: Portable Operating System Interface.
 
 [[prefetch]]Prefetchable:: Follows PCI Express. Defines the property of the memory space used by a device. For details, see the PCIe Base Specification. Broadly, non-prefetchable space covers any locations where reads have side effects or where writes cannot be merged.
+
+[[pointermasking]]Pointer masking:: An arithmetic operation, defined by the pointer-masking extensions (Smmpm, Smnpm, Ssnpm, Sspm, and Supm), that transforms an address by masking a configurable number of its upper bits before the address is used to access memory.
 
 [[PRI]]PRI:: Page Request Interface. A PCIe protocol that enables devices to requeprist OS memory manager services to make pages resident.
 
@@ -342,6 +350,8 @@ environment.
 [[tenantsoft]]Tenant software:: All software elements owned and deployed by a tenant in a multi-tenant hosting environment. These elements include VS-mode guest kernel and VU-mode guest user-space software.
 
 [[TLB]]TLB:: Translation Lookaside Buffer. A memory buffer that enhances speed in retrieving a value by storing a memory address.
+
+[[transformedaddress]]Transformed address:: An effective address after the pointer-masking ignore transformation has been applied.
 
 [[TRNG]]TRNG:: True Random Number Generator. Also known as HRNG, or Hardware Random Number Generator. A device that generates random numbers from a physical process, rather than by means of an algorithm. Such devices are often based on microscopic phenomena that generate low-level, statistically random "noise" signals, like thermal noise, the photoelectric effect involving a beam splitter, and other quantum phenomena.
 

--- a/src/glossary.adoc
+++ b/src/glossary.adoc
@@ -189,6 +189,8 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 
 [[nonprefetch]]Non-prefetchable:: Follows PCI Express. Defines the property of the memory space used by a device. For details, see the PCIe Base Specification. Broadly, non-prefetchable space covers any locations where reads have side effects or where writes cannot be merged.
 
+[[NVBITS]]NVBITS:: Non-effective Virtual Address Bits. Upper bits of a virtual address that have no effect on memory addressing and are used only for address-validity checks. Used by pointer masking.
+
 [[objectfile]]Object file:: A binary file including machine instructions, symbols, and relocation information. Normally produced by an assembler.
 
 [[objectfileformat]]Object file format:: The format of an object file.  Typically object files and executables for a specific system are in the same format, although executables do not contain any relocation information.
@@ -230,6 +232,12 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 [[POSIX]]POSIX:: Portable Operating System Interface.
 
 [[prefetch]]Prefetchable:: Follows PCI Express. Defines the property of the memory space used by a device. For details, see the PCIe Base Specification. Broadly, non-prefetchable space covers any locations where reads have side effects or where writes cannot be merged.
+
+[[PM]]PM:: Pointer Masking. An operation that transforms an address by masking a number of its upper bits before the address is used to access memory.
+
+[[PMLEN]]PMLEN:: Pointer Masking Length. The number of upper address bits that are masked by pointer masking.
+
+[[PMM]]PMM:: Pointer Masking Mode. The CSR field that configures pointer-masking behavior.
 
 [[pointermasking]]Pointer masking:: An arithmetic operation, defined by the pointer-masking extensions (Smmpm, Smnpm, Ssnpm, Sspm, and Supm), that transforms an address by masking a configurable number of its upper bits before the address is used to access memory.
 
@@ -364,6 +372,8 @@ environment.
 [[UR]]UR:: Error returns to an access made to a PCIe hierarchy.
 
 [[userlevelsb]]User level sandboxing:: A form of sandboxing that can be implemented by the pointer masking proposal where runtime and sandboxed code all run within the user mode and the sandboxed code was checked by the runtime to be unable to change pointer masks.
+
+[[VBITS]]VBITS:: Virtual Address Bits. The bits within a virtual address that determine which memory is addressed. See <<NVBITS>>.
 
 [[virtualtraps]]Virtical traps:: A trap that increases privilege mode when triggered. For example, increasing from U to S.
 


### PR DESCRIPTION
This adds glossary and acronym entries for the RISC-V pointer masking feature.

Terms and definitions are sourced from the [Zjpm pointer masking specification](https://github.com/riscv/riscv-j-extension/blob/master/zjpm/background.adoc) referenced in the issue.

## Changes

`src/glossary.adoc` (terms):
- Effective address
- Ignore transformation
- Masked bits
- Pointer masking
- Transformed address

`src/acronyms.adoc` (acronyms):
- NVBITS (Non-effective Virtual Address Bits)
- PM (Pointer Masking)
- PMLEN (Pointer Masking Length)
- PMM (Pointer Masking Mode)
- VBITS (Virtual Address Bits)

Entries are inserted alphabetically among their existing neighbors. The Pointer masking definition names the related extensions (Smmpm, Smnpm, Ssnpm, Sspm, Supm) for cross-reference.

Closes #18