### PR TITLE
docs: fix spelling typos in glossary, acronyms, and readme

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -2,7 +2,7 @@
 
 This repo contains the RISC-V glossary. The glossary includes RISC-V specific terms, definitions, and acronyms as well as some commonly used computer architecture definitions. 
 
-## How can I add or edit a term, defintion, or acronym?
+## How can I add or edit a term, definition, or acronym?
 
 You can add a term, definition, or acronym to the RISC-V glossary in the following ways.
 

--- a/src/acronyms.adoc
+++ b/src/acronyms.adoc
@@ -182,7 +182,7 @@ Entries marked ^RV^ are specific to the RISC-V architecture. Unmarked entries ar
 
 [[IC]]IC:: Integrated Circuit.
 
-[[ICF]]ICF:: Indentical Code Folding.
+[[ICF]]ICF:: Identical Code Folding.
 
 [[IComdatF]]ICF:: Identical COMDAT Folding.
 
@@ -402,7 +402,7 @@ Entries marked ^RV^ are specific to the RISC-V architecture. Unmarked entries ar
 
 [[RID]]RID:: Requester ID.
 
-[[RC]]RC:: Root Comple.
+[[RC]]RC:: Root Complex.
 
 [[RD]]RD:: Resource Data.
 

--- a/src/glossary.adoc
+++ b/src/glossary.adoc
@@ -36,7 +36,7 @@ This glossary includes definitions of terms specific to RISC-V as well as terms 
 [[COFF]]COFF:: The Common Object File Format. Used on Unix SVR3 and by some
 embedded targets, although ELF is normally chosen.
 
-[[confidentialComputing]]Confidentail computing:: A computing paradigm that protects data in use by performing computation in a hardware-based, attested Trusted Execution Environment (TEE).
+[[confidentialComputing]]Confidential computing:: A computing paradigm that protects data in use by performing computation in a hardware-based, attested Trusted Execution Environment (TEE).
 
 [[CPUCache]]CPU Cache:: Many CPUs include three kinds of caches to speed up data retrieval: an instruction cache for executable instruction fetch, a data cache for data store and fetch, and a translation lookaside buffer (TLB) for virtual-to-physical address translation for executable instructions and data.
 
@@ -44,7 +44,7 @@ embedded targets, although ELF is normally chosen.
 
 [[conapp]]Confidential application:: A user-mode application or library instantiation in a TVM. The user-mode application may be supported via a trusted runtime. The user-mode library may be hosted by a surrogate process runtime.
 
-[[conlib]]Confidentail library:: See <<conapp>>.
+[[conlib]]Confidential library:: See <<conapp>>.
 
 [[conmem]]Confidential memory:: Memory that is subject to access-control, confidentiality and integrity mechanisms per the threat model for use in the CoVE system. Confidential memory may also be used by nonTCB/ hosting software with appropriate TCB controls on the configuration, e.g., a separate key used for TCB and non-TCB elements.
 
@@ -91,7 +91,7 @@ unique device identifier to locate the Device Context structure.
 
 [[executable]]Executable:: A program, with instructions and symbols, and perhaps dynamic linking information. Normally produced by a linker.
 
-[[extension]]Extension:: An instructon set that adds customization and specialization to each base integer ISA. An extension is categorized as Standard, Custom, or Non-conforming. 
+[[extension]]Extension:: An instruction set that adds customization and specialization to each base integer ISA. An extension is categorized as Standard, Custom, or Non-conforming. 
 
 [[FFH]]FFH:: Functional Fixed Hardware, as it pertains to ACPI.
 
@@ -107,7 +107,7 @@ unique device identifier to locate the Device Context structure.
 
 [[HART]]HART:: An abstraction of a hardware thread that captures the important aspects of a real hardware thread for the purposes of defining the RISC-V specifications. In particular, a hart is the agent that executes instructions within an execution context.
 
-[[HBI]]HBI:: Hypervisor Binary Interface. An interface for hypervisors to connect the HEE, isolating the hypervisor from details ofthe hardware platform. See 1.1. RISC-V Privileged Software Stack Terminology.
+[[HBI]]HBI:: Hypervisor Binary Interface. An interface for hypervisors to connect the HEE, isolating the hypervisor from details of the hardware platform. See 1.1. RISC-V Privileged Software Stack Terminology.
 
 [[hcounteren]]hcounteren:: Hypervisor Counter-enable register.
 
@@ -121,7 +121,7 @@ unique device identifier to locate the Device Context structure.
 
 [[hideleg]]hideleg:: Hypervisor Trap Delegation register. Also `hedeleg`.
 
-[[horizontaltrap]]Horizontal trap:: A trap that stays at the current priviledge mode when triggered.
+[[horizontaltrap]]Horizontal trap:: A trap that stays at the current privilege mode when triggered.
 
 [[hostbridge]]Host Bridge:: Part of a SoC that connects host CPUs and memory to PCIe root ports, RCiEP, and non-PCIe devices integrated in the SoC. The host bridge is placed between the device(s) and the platform interconnect to process DMA transactions. IO Devices may perform DMA transactions using IO Virtual Addresses (VA, GVA or GPA). The host bridge invokes the associated IOMMU to translate the IOVA to Supervisor Physical Addresses (SPA). Also called IO Bridge.
 
@@ -134,7 +134,7 @@ unique device identifier to locate the Device Context structure.
 [[IALIGN]]IALIGN:: Refers to the instruction-address alignment constraint
 that the implementation enforces. Measured in bits.
 
-[[ICF]]ICF:: Indentical Code Folding. ICF is an optimization to reduce output size by merging read-only sections by not only their names but by their contents. If two read-only sections happen to have the same metadata , actual contents and relocations, they are merged by ICF. It is known as an effective technique, and it usually reduces C++ program's size by a few percent or more.
+[[ICF]]ICF:: Identical Code Folding. ICF is an optimization to reduce output size by merging read-only sections by not only their names but by their contents. If two read-only sections happen to have the same metadata , actual contents and relocations, they are merged by ICF. It is known as an effective technique, and it usually reduces C++ program's size by a few percent or more.
 
 [[IDsync]]ID Synchronization:: The mechanisms by which code generated on a core (e.g., by a JIT compiler) is made visible to other cores.
 
@@ -161,7 +161,7 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 
 [[IRC]]IRC:: Internet Relay Chat. A protocol is for use with text based conferencing; the simplest client being any socket program capable of connecting to the server. See https://tools.ietf.org/html/rfc2812[Internet Relay Chat].
 
-[[ISA]]ISA:: Instruction set architecture. Programmer visible state that represence the boundary between hardware and software. Includes operations on that state.
+[[ISA]]ISA:: Instruction set architecture. Programmer visible state that represents the boundary between hardware and software. Includes operations on that state.
 
 [[instructionset]]Instruction Set:: A group of commands for a CPU in machine language that refers to all possible instructions for a CPU, or a subset of instructions to enhance its performance in specific situations.
 
@@ -221,7 +221,7 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 
 [[platform]]Platform:: A System Platform is a set of features users can depend on working together that includes things such as ISA Profiles, software components, hardware system components, standardized hardware/software interfaces, and other features. Currently RISC-V has defined two Platform types: OS/A and M (naming TBD).
 
-[[PLL]]PLL:: Phase-Locked Loop. A control system that generates anoutput signal whose phase is related to the phase of an input signal. PLLs are commonly used to perform clock synthesis.
+[[PLL]]PLL:: Phase-Locked Loop. A control system that generates an output signal whose phase is related to the phase of an input signal. PLLs are commonly used to perform clock synthesis.
 
 [[PLIC]]PLIC:: Platform-Level Interrupt Controller. Used for handling global interrupts in RISC-V systems.
 
@@ -241,7 +241,7 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 
 [[pointermasking]]Pointer masking:: An arithmetic operation, defined by the pointer-masking extensions (Smmpm, Smnpm, Ssnpm, Sspm, and Supm), that transforms an address by masking a configurable number of its upper bits before the address is used to access memory.
 
-[[PRI]]PRI:: Page Request Interface. A PCIe protocol that enables devices to requeprist OS memory manager services to make pages resident.
+[[PRI]]PRI:: Page Request Interface. A PCIe protocol that enables devices to request OS memory manager services to make pages resident.
 
 [[privileged]]Privileged:: Includes machine and supervisor mode. Privileged provides security isolation and reduces code defects because code does not have to check for illegal values. Privileged contains state, is used primarily to run applications and can be used to debug implementations. It defines CSR address space and content trap when taken increases privilege mode (say from U to S) trap when taken stays at the current privilege mode access more than even M mode. Its addresses reserved in ISA. address includes highest mode that access the CSR and if it is `r/w/rw/none` preserve bits already there when you change a field.
 
@@ -251,7 +251,7 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 
 [[PSCID]]PSCID:: Process soft-context identifier. An identification number used by software to identify a unique address space. The IOMMU may tag IOATC entries with PSCID.
 
-[[pseudoinstructions]]Psuedo instructions:: In support of a core design goal for RISC-V ISAs--high performance--pseudo instructions often include special commands to the assembler. The use of pseudo instructions supports a policy of keeping the instruction set as small as possible, while supporting optimization and adding clarity to software programming. For example, the use of a pseudo instruction enables loading into memory with a 32-bit offset (called big) that is not directly available, because only 16-bit offsets are permitted.
+[[pseudoinstructions]]Pseudo instructions:: In support of a core design goal for RISC-V ISAs--high performance--pseudo instructions often include special commands to the assembler. The use of pseudo instructions supports a policy of keeping the instruction set as small as possible, while supporting optimization and adding clarity to software programming. For example, the use of a pseudo instruction enables loading into memory with a 32-bit offset (called big) that is not directly available, because only 16-bit offsets are permitted.
 
 [[PTE]]PTE:: Page Table Entry. An entry in the data structure used by virtual memory in the operating system to store the mapping between both virtual addresses and physical addresses, that enables access data in memory.
 
@@ -271,7 +271,7 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 
 [[RID]]RID:: Requester ID. Follows PCI Express. An identifier that uniquely identifies the requester within a PCIe Hierarchy. Needs to be extended with a Hierarchy ID to ensure it is unique across the platform.
 
-[[RC]]RC:: Root Comple. Follows PCI Express. Part of the SoC that includes the Host Bridge, Root Port, and RCiEP.
+[[RC]]RC:: Root Complex. Follows PCI Express. Part of the SoC that includes the Host Bridge, Root Port, and RCiEP.
 
 [[register]]Register:: A group of flip-flops with each flip-flop capable of storing one bit of information. The simplest register is one that consists of only flip-flops with no external gates.
 
@@ -307,7 +307,7 @@ implementation. ILEN is a multiple of IALIGN and measured in bits.
 
 [[S]]S:: Supervisor mode. The boot mode that provides support for operating systems, such as Linux. Also called S-mode. See 1.2. Privilege Levels.
 
-[[satp]]satp:: Supervisor Address Translation and Protection. XLEN-bit read/write register that controls supervisor-mode address translation and protection and holds the physical page number (PPN) of the root page table--an address space identifer (ASID) that facilitates address-translation fences
+[[satp]]satp:: Supervisor Address Translation and Protection. XLEN-bit read/write register that controls supervisor-mode address translation and protection and holds the physical page number (PPN) of the root page table--an address space identifier (ASID) that facilitates address-translation fences
 on a per-address-space basis, and the MODE field, which selects the current address-translation scheme.
 
 [[SysBI]]SBI:: System Binary Interface. SBI abstracts the interfaces that are required to run operating systems.
@@ -324,7 +324,7 @@ on a per-address-space basis, and the MODE field, which selects the current addr
 
 [[segfault]]Segmentation fault:: A failure condition caused by a memory access violation in hardware operating with memory protection. The fault process notifies the operating system (OS) that software has attempted to access a restricted area of memory.
 
-[[SFENCE]]SFENCE:: Store fence. A store fence orders the processor execution, releative to all memory stores. See 10.2.1 Supervisor Memory-Management Fence Instruction in the Priv ISA manual.
+[[SFENCE]]SFENCE:: Store fence. A store fence orders the processor execution, relative to all memory stores. See 10.2.1 Supervisor Memory-Management Fence Instruction in the Priv ISA manual.
 
 [[SHA]]SHA:: Secure Hash Algorithms. A family of cryptographic hash functions published by the National Institute of Standards and Technology as a U.S. Federal Information Processing Standard that started with what is now known as SHA-0, a retronym used for the original (1993) 160-bit hash function published under the name "SHA".
 
@@ -332,7 +332,7 @@ on a per-address-space basis, and the MODE field, which selects the current addr
 
 [[SP800900]]SP 800 90B:: Used in military and US government random security evaluations, written by NIST.
 
-[[SPA]]SPA:: Supervisor Physical Address. Physical address used to to access memory and memory-mapped resources.
+[[SPA]]SPA:: Supervisor Physical Address. Physical address used to access memory and memory-mapped resources.
 
 [[SPDM]]SPDM:: Security Protocols and Data Models. Follows DMTF Standard. A standard for authentication, attestation and key exchange to assist in providing infrastructure security enablement.
 
@@ -350,7 +350,7 @@ on a per-address-space basis, and the MODE field, which selects the current addr
 
 [[TAP]]TAP:: TVM attestation payload. TAP is a block of memory in a VM that TSM uses to perform local attestation as part of promoting a VM to a TVM.
 
-[[TCB]]TCB:: Trusted Compute Base. TCB is the hardware, software, and firmware elements that are trustedby a relying party to protect the confidentiality and integrity of the relying parties' workload data and execution against a defined adversary model. In a system with separate processing elements within a package on a socket, the TCB boundary is the package. In a multi-socket system the Hardware TCB extends across the socket-tosocket interface, and is managed as one system TCB. The software TCB may also extends across multiple sockets.
+[[TCB]]TCB:: Trusted Compute Base. TCB is the hardware, software, and firmware elements that are trusted by a relying party to protect the confidentiality and integrity of the relying parties' workload data and execution against a defined adversary model. In a system with separate processing elements within a package on a socket, the TCB boundary is the package. In a multi-socket system the Hardware TCB extends across the socket-to-socket interface, and is managed as one system TCB. The software TCB may also extends across multiple sockets.
 
 [[TEE]]TEE:: Trusted Execution Environment. TEE is a set of hardware and software mechanisms that allow attestable creation and isolated execution
 environment.
@@ -367,7 +367,7 @@ environment.
 
 [[U]]U:: User mode. The boot mode that runs the application code. Part of Unprivileged. Also called U-mode. See 1.2. Privilege Levels.
 
-[[unprivileged]]Unpriveleged:: Unprivileged instructions are those that are generally usable in all privilege modes in all privileged architectures, though behavior can vary, depending on the specific privilege mode and privilege architecture.
+[[unprivileged]]Unprivileged:: Unprivileged instructions are those that are generally usable in all privilege modes in all privileged architectures, though behavior can vary, depending on the specific privilege mode and privilege architecture.
 
 [[UR]]UR:: Error returns to an access made to a PCIe hierarchy.
 
@@ -375,7 +375,7 @@ environment.
 
 [[VBITS]]VBITS:: Virtual Address Bits. The bits within a virtual address that determine which memory is addressed. See <<NVBITS>>.
 
-[[virtualtraps]]Virtical traps:: A trap that increases privilege mode when triggered. For example, increasing from U to S.
+[[virtualtraps]]Vertical traps:: A trap that increases privilege mode when triggered. For example, increasing from U to S.
 
 [[VM]]VM:: Virtual Machine. An efficient, isolated duplicate of a physical computer system.
 


### PR DESCRIPTION
## What

Fixes clear spelling typos in the glossary definition text across three files. No terms were reworded and no anchor IDs or RISC-V extension names were touched, so all cross-references and `<<anchor>>` links keep working.

`src/glossary.adoc`
- Confidentail -> Confidential (two entries)
- instructon -> instruction
- ofthe -> of the
- priviledge -> privilege
- Indentical -> Identical
- represence -> represents
- anoutput -> an output
- requeprist -> request
- Psuedo -> Pseudo
- identifer -> identifier
- releative -> relative
- "used to to access" -> "used to access"
- trustedby -> trusted by
- socket-tosocket -> socket-to-socket
- Root Comple -> Root Complex
- Unpriveleged -> Unprivileged
- Virtical traps -> Vertical traps (matches the Horizontal/Vertical trap pairing already in the glossary)

`src/acronyms.adoc`
- Indentical -> Identical
- Root Comple -> Root Complex

`readme.adoc`
- defintion -> definition

## Why

These are genuine misspellings in existing content, several of them surfaced by the repository's own Vale spell-check runs. They are unrelated to the RISC-V extension names that Vale flags in other files (those are valid names missing from Vale's dictionary, not typos).
